### PR TITLE
Convert UTC to JST at HttpTrigger

### DIFF
--- a/sources/MyHomeMeasure/MyHomeMeasure/MyHomeMeasure.csproj
+++ b/sources/MyHomeMeasure/MyHomeMeasure/MyHomeMeasure.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.9.2" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.5.1" />
+    <PackageReference Include="TimeZoneConverter" Version="3.2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">
@@ -22,5 +23,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Services\" />
+    <Folder Include="Utl\" />
   </ItemGroup>
 </Project>

--- a/sources/MyHomeMeasure/MyHomeMeasure/Utl/DateUtil.cs
+++ b/sources/MyHomeMeasure/MyHomeMeasure/Utl/DateUtil.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using TimeZoneConverter;
+
+namespace MyHomeMeasure.Utl
+{
+    public static class DateUtil
+    {
+        private static readonly TimeZoneInfo _jstTimeZone = TZConvert.GetTimeZoneInfo("Tokyo Standard Time");
+
+        public static DateTime ConvertUtcToJst(this DateTime utc)
+        {
+            return TimeZoneInfo.ConvertTimeFromUtc(utc, _jstTimeZone);
+        }
+
+        public static DateTime ConvertJstToUtc(this DateTime jst)
+        {
+            return TimeZoneInfo.ConvertTimeToUtc(jst, _jstTimeZone);
+        }
+    }
+}


### PR DESCRIPTION
#7 
Linux/Macだと`TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time")` が使えない模様。
なので、 `TimeZoneConverter` をnugetで入れた

出典: https://blog.hitsujin.jp/entry/2019/01/29/173138
